### PR TITLE
add support for expanding ${file}. if ${file} is used, reload on completion

### DIFF
--- a/run_task.py
+++ b/run_task.py
@@ -367,7 +367,7 @@ class RunTaskCommand(sublime_plugin.WindowCommand):
 		self.workspace = folders[0]
 		self.tasks = []
 
-		project_file = OSUtils.find_file_with_pattern(self.workspace, PROJECT_FILE_NAME_PATTERN)
+		project_file = self.window.project_file_name()
 		if project_file:
 			with open(project_file, "r") as fp:
 				try:


### PR DESCRIPTION
- Add support for expanding ${file}. if ${file} is used, reload the file on completion.
With this you can run a program on the current file, IE if for checking out a file in perforce:

		{
			"name": "p4 edit",
			"type": "shell",
			"command": "p4",
			"args": "edit ${file}",
			"windows": {
				"command": "p4",
				"args": "edit ${file}",
			},
			"show_output_panel": true,
		},
- Fixed an issue where the project file would not be found, if it wasn't located in the first folder of the project.
- The project file parser now removes trailing commas in from the project file, and accepts its, in the same way sublime text itself does.
- The project file parser now prints the line where it fails parsing the project file.

